### PR TITLE
Change version that pyston is compatiable with

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Based on [docker-pypy](https://github.com/zoidbergwill/docker-pyston)
 
 A minimal Ubuntu 14.04 based Docker image for Pyston 0.4. There are plans for an `onbuild` variant, but a PR would be aprpeciated.
 
-- [pyston:0.4](https://github.com/zoidbergwill/docker-pyston/blob/master/ubuntu/Dockerfile) __compatible with python-2.7.10__
+- [pyston:0.4](https://github.com/zoidbergwill/docker-pyston/blob/master/ubuntu/Dockerfile) __compatible with python-2.7.7__
 
 Setup:
 ---


### PR DESCRIPTION
I think it's targeting 2.7.7, not 2.7.10

```
# docker run -it --rm 6118152a18a3
Pyston v0.4.0 (rev e8412dcaeb07b49385a4cb328e3bec3bc7f4a085), targeting Python 2.7.7
>> 
```
